### PR TITLE
feat: add `-h` flag that display help

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,8 +13,10 @@ import fastGlob from 'fast-glob'
 import inclusion from 'inclusion'
 import { pathToFileURL } from 'url'
 import { Hooks } from '@poppinss/hooks'
+import { logger } from '@poppinss/cliui'
 import { ErrorsPrinter } from '@japa/errors-printer'
 import { Emitter, Refiner, TestExecutor, ReporterContract } from '@japa/core'
+import { version } from './package.json'
 import { Test, TestContext, Group, Suite, Runner } from './src/Core'
 import {
   Config,
@@ -436,6 +438,29 @@ export async function run() {
   }
 }
 
+function showHelp() {
+  const green = logger.colors.green.bind(logger.colors)
+  const grey = logger.colors.grey.bind(logger.colors)
+
+  console.log(`@japa/runner v${version}
+
+Options:
+  ${green('--tests')}                     ${grey('Specify test titles')}
+  ${green('--tags')}                      ${grey('Specify test tags')}
+  ${green('--groups')}                    ${grey('Specify group titles')}
+  ${green('--ignore-tags')}               ${grey('Specify negated tags')}
+  ${green('--files')}                     ${grey('Specify files to match and run')}
+  ${green('--force-exit')}                ${grey('Enable/disable force exit')}
+  ${green('--timeout')}                   ${grey('Define timeout for all the tests')}
+  ${green('-h, --help')}                  ${grey('Display this message')}
+
+Examples:
+  ${grey('$ node bin/test.js --tags="@github"')}
+  ${grey('$ node bin/test.js --files="example.spec.js" --force-exit')}`)
+
+  process.exit(0)
+}
+
 /**
  * Process CLI arguments into configuration options. The following
  * command line arguments are processed.
@@ -447,14 +472,16 @@ export async function run() {
  * * --files=Specify files to match and run
  * * --force-exit=Enable/disable force exit
  * * --timeout=Define timeout for all the tests
+ * * -h, --help=Show help
  */
 export function processCliArgs(argv: string[]): Partial<Config> {
   const parsed = getopts(argv, {
     string: ['tests', 'tags', 'groups', 'ignoreTags', 'files', 'timeout'],
-    boolean: ['forceExit'],
+    boolean: ['forceExit', 'help'],
     alias: {
       ignoreTags: 'ignore-tags',
       forceExit: 'force-exit',
+      help: 'h',
     },
   })
 
@@ -470,6 +497,13 @@ export function processCliArgs(argv: string[]): Partial<Config> {
   processAsString(parsed, 'groups', (groups) => (config.filters.groups = groups))
   processAsString(parsed, 'tests', (tests) => (config.filters.tests = tests))
   processAsString(parsed, 'files', (files) => (config.filters.files = files))
+
+  /**
+   * Show help
+   */
+  if (parsed.help) {
+    showHelp()
+  }
 
   /**
    * Get suites

--- a/index.ts
+++ b/index.ts
@@ -457,8 +457,6 @@ Options:
 Examples:
   ${grey('$ node bin/test.js --tags="@github"')}
   ${grey('$ node bin/test.js --files="example.spec.js" --force-exit')}`)
-
-  process.exit(0)
 }
 
 /**
@@ -503,6 +501,7 @@ export function processCliArgs(argv: string[]): Partial<Config> {
    */
   if (parsed.help) {
     showHelp()
+    process.exit(0)
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@japa/core": "^6.0.6",
         "@japa/errors-printer": "^1.3.9",
+        "@poppinss/cliui": "^3.0.2",
         "@poppinss/hooks": "^6.0.2-0",
         "fast-glob": "^3.2.11",
         "getopts": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mrm": "mrm --preset=@adonisjs/mrm-preset",
     "pretest": "npm run lint",
     "test": "node .bin/test.js",
-    "clean": "del build",
+    "clean": "del-cli build",
     "compile": "npm run lint && npm run clean && tsc",
     "build": "npm run compile",
     "prepublishOnly": "npm run build",
@@ -107,6 +107,7 @@
   "dependencies": {
     "@japa/core": "^6.0.6",
     "@japa/errors-printer": "^1.3.9",
+    "@poppinss/cliui": "^3.0.2",
     "@poppinss/hooks": "^6.0.2-0",
     "fast-glob": "^3.2.11",
     "getopts": "^2.3.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./node_modules/@adonisjs/mrm-preset/_tsconfig"
+  "extends": "./node_modules/@adonisjs/mrm-preset/_tsconfig",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
 }


### PR DESCRIPTION
## Proposed changes

Just added a -h argument that displays a help message

![image](https://user-images.githubusercontent.com/8337858/188006019-84088db4-69b9-41c8-bd48-6222e76229c9.png)

Closes #20 
