### PR TITLE
New API for `configure.reporters` and `--reporters` argument

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,13 +7,11 @@
  * file that was distributed with this source code.
  */
 
-import getopts from 'getopts'
 import { extname } from 'path'
 import fastGlob from 'fast-glob'
 import inclusion from 'inclusion'
 import { pathToFileURL } from 'url'
 import { Hooks } from '@poppinss/hooks'
-import { logger } from '@poppinss/cliui'
 import { ErrorsPrinter } from '@japa/errors-printer'
 import { Test, TestContext, Group, Suite, Runner } from './src/Core'
 import { Emitter, Refiner, TestExecutor, ReporterContract } from '@japa/core'
@@ -114,20 +112,6 @@ function validateSuitesFilter() {
 }
 
 /**
- * Process command line argument into a string value
- */
-function processAsString(
-  argv: Record<string, any>,
-  flagName: string,
-  onMatch: (value: string[]) => any
-): void {
-  const flag = argv[flagName]
-  if (flag) {
-    onMatch((Array.isArray(flag) ? flag : flag.split(',')).map((tag: string) => tag.trim()))
-  }
-}
-
-/**
  * Find if the file path matches the files filter array.
  * The ending of the file is matched
  */
@@ -209,30 +193,6 @@ async function endTests(runner: Runner) {
 }
 
 /**
- * Show help output in stdout.
- */
-function showHelp() {
-  const green = logger.colors.green.bind(logger.colors)
-  const grey = logger.colors.grey.bind(logger.colors)
-
-  console.log(`@japa/runner v2.1.1
-
-Options:
-  ${green('--tests')}                     ${grey('Specify test titles')}
-  ${green('--tags')}                      ${grey('Specify test tags')}
-  ${green('--groups')}                    ${grey('Specify group titles')}
-  ${green('--ignore-tags')}               ${grey('Specify negated tags')}
-  ${green('--files')}                     ${grey('Specify files to match and run')}
-  ${green('--force-exit')}                ${grey('Enable/disable force exit')}
-  ${green('--timeout')}                   ${grey('Define timeout for all the tests')}
-  ${green('-h, --help')}                  ${grey('Display this message')}
-
-Examples:
-  ${grey('$ node bin/test.js --tags="@github"')}
-  ${grey('$ node bin/test.js --files="example.spec.js" --force-exit')}`)
-}
-
-/**
  * Configure the tests runner
  */
 export function configure(options: Config) {
@@ -253,78 +213,6 @@ export function configure(options: Config) {
   }
 
   runnerOptions = Object.assign(defaultOptions, options)
-}
-
-/**
- * Process CLI arguments into configuration options. The following
- * command line arguments are processed.
- *
- * * --tests=Specify test titles
- * * --tags=Specify test tags
- * * --groups=Specify group titles
- * * --ignore-tags=Specify negated tags
- * * --files=Specify files to match and run
- * * --force-exit=Enable/disable force exit
- * * --timeout=Define timeout for all the tests
- * * -h, --help=Show help
- */
-export function processCliArgs(argv: string[]): Partial<Config> {
-  const parsed = getopts(argv, {
-    string: ['tests', 'tags', 'groups', 'ignoreTags', 'files', 'timeout'],
-    boolean: ['forceExit', 'help'],
-    alias: {
-      ignoreTags: 'ignore-tags',
-      forceExit: 'force-exit',
-      help: 'h',
-    },
-  })
-
-  const config: { filters: Filters; timeout?: number; forceExit?: boolean } = {
-    filters: {},
-  }
-
-  processAsString(parsed, 'tags', (tags) => (config.filters.tags = tags))
-  processAsString(parsed, 'ignoreTags', (tags) => {
-    config.filters.tags = config.filters.tags || []
-    tags.forEach((tag) => config.filters.tags!.push(`!${tag}`))
-  })
-  processAsString(parsed, 'groups', (groups) => (config.filters.groups = groups))
-  processAsString(parsed, 'tests', (tests) => (config.filters.tests = tests))
-  processAsString(parsed, 'files', (files) => (config.filters.files = files))
-
-  /**
-   * Show help
-   */
-  if (parsed.help) {
-    showHelp()
-    process.exit(0)
-  }
-
-  /**
-   * Get suites
-   */
-  if (parsed._.length) {
-    processAsString({ suites: parsed._ }, 'suites', (suites) => (config.filters.suites = suites))
-  }
-
-  /**
-   * Get timeout
-   */
-  if (parsed.timeout) {
-    const value = Number(parsed.timeout)
-    if (!isNaN(value)) {
-      config.timeout = value
-    }
-  }
-
-  /**
-   * Get forceExit
-   */
-  if (parsed.forceExit) {
-    config.forceExit = true
-  }
-
-  return config
 }
 
 /**
@@ -561,3 +449,5 @@ test.group = function (title: string, callback: (group: Group) => void) {
   callback(activeGroup)
   activeGroup = undefined
 }
+
+export { processCliArgs } from './src/CliProcessor'

--- a/src/CliProcessor/index.ts
+++ b/src/CliProcessor/index.ts
@@ -78,7 +78,7 @@ export function processCliArgs(argv: string[]): ProcessedCliArgs {
     filters: Filters
     timeout?: number
     forceExit?: boolean
-    defaultsReporters?: string[]
+    cliReporters?: string[]
   } = { filters: {} }
 
   processAsString(parsed, 'tags', (tags) => (config.filters.tags = tags))
@@ -89,7 +89,7 @@ export function processCliArgs(argv: string[]): ProcessedCliArgs {
   processAsString(parsed, 'groups', (groups) => (config.filters.groups = groups))
   processAsString(parsed, 'tests', (tests) => (config.filters.tests = tests))
   processAsString(parsed, 'files', (files) => (config.filters.files = files))
-  processAsString(parsed, 'reporters', (reporters) => (config.defaultsReporters = reporters))
+  processAsString(parsed, 'reporters', (reporters) => (config.cliReporters = reporters))
 
   /**
    * Show help

--- a/src/CliProcessor/index.ts
+++ b/src/CliProcessor/index.ts
@@ -1,0 +1,123 @@
+/*
+ * @japa/runner
+ *
+ * (c) Japa
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+import getopts from 'getopts'
+import { logger } from '@poppinss/cliui'
+import { Config, Filters } from '../Contracts'
+
+/**
+ * Process command line argument into a string value
+ */
+function processAsString(
+  argv: Record<string, any>,
+  flagName: string,
+  onMatch: (value: string[]) => any
+): void {
+  const flag = argv[flagName]
+  if (flag) {
+    onMatch((Array.isArray(flag) ? flag : flag.split(',')).map((tag: string) => tag.trim()))
+  }
+}
+
+/**
+ * Show help output in stdout.
+ */
+function showHelp() {
+  const green = logger.colors.green.bind(logger.colors)
+  const grey = logger.colors.grey.bind(logger.colors)
+
+  console.log(`@japa/runner v2.1.1
+
+Options:
+  ${green('--tests')}                     ${grey('Specify test titles')}
+  ${green('--tags')}                      ${grey('Specify test tags')}
+  ${green('--groups')}                    ${grey('Specify group titles')}
+  ${green('--ignore-tags')}               ${grey('Specify negated tags')}
+  ${green('--files')}                     ${grey('Specify files to match and run')}
+  ${green('--force-exit')}                ${grey('Enable/disable force exit')}
+  ${green('--timeout')}                   ${grey('Define timeout for all the tests')}
+  ${green('-h, --help')}                  ${grey('Display this message')}
+
+Examples:
+  ${grey('$ node bin/test.js --tags="@github"')}
+  ${grey('$ node bin/test.js --files="example.spec.js" --force-exit')}`)
+}
+
+/**
+ * Process CLI arguments into configuration options. The following
+ * command line arguments are processed.
+ *
+ * * --tests=Specify test titles
+ * * --tags=Specify test tags
+ * * --groups=Specify group titles
+ * * --ignore-tags=Specify negated tags
+ * * --files=Specify files to match and run
+ * * --force-exit=Enable/disable force exit
+ * * --timeout=Define timeout for all the tests
+ * * -h, --help=Show help
+ */
+export function processCliArgs(argv: string[]): Partial<Config> {
+  const parsed = getopts(argv, {
+    string: ['tests', 'tags', 'groups', 'ignoreTags', 'files', 'timeout'],
+    boolean: ['forceExit', 'help'],
+    alias: {
+      ignoreTags: 'ignore-tags',
+      forceExit: 'force-exit',
+      help: 'h',
+    },
+  })
+
+  const config: {
+    filters: Filters
+    timeout?: number
+    forceExit?: boolean
+  } = { filters: {} }
+
+  processAsString(parsed, 'tags', (tags) => (config.filters.tags = tags))
+  processAsString(parsed, 'ignoreTags', (tags) => {
+    config.filters.tags = config.filters.tags || []
+    tags.forEach((tag) => config.filters.tags!.push(`!${tag}`))
+  })
+  processAsString(parsed, 'groups', (groups) => (config.filters.groups = groups))
+  processAsString(parsed, 'tests', (tests) => (config.filters.tests = tests))
+  processAsString(parsed, 'files', (files) => (config.filters.files = files))
+
+  /**
+   * Show help
+   */
+  if (parsed.help) {
+    showHelp()
+    process.exit(0)
+  }
+
+  /**
+   * Get suites
+   */
+  if (parsed._.length) {
+    processAsString({ suites: parsed._ }, 'suites', (suites) => (config.filters.suites = suites))
+  }
+
+  /**
+   * Get timeout
+   */
+  if (parsed.timeout) {
+    const value = Number(parsed.timeout)
+    if (!isNaN(value)) {
+      config.timeout = value
+    }
+  }
+
+  /**
+   * Get forceExit
+   */
+  if (parsed.forceExit) {
+    config.forceExit = true
+  }
+
+  return config
+}

--- a/src/CliProcessor/index.ts
+++ b/src/CliProcessor/index.ts
@@ -8,7 +8,7 @@
  */
 import getopts from 'getopts'
 import { logger } from '@poppinss/cliui'
-import { Config, Filters } from '../Contracts'
+import { Filters, ProcessedCliArgs } from '../Contracts'
 
 /**
  * Process command line argument into a string value
@@ -41,6 +41,7 @@ Options:
   ${green('--files')}                     ${grey('Specify files to match and run')}
   ${green('--force-exit')}                ${grey('Enable/disable force exit')}
   ${green('--timeout')}                   ${grey('Define timeout for all the tests')}
+  ${green('--reporters')}                  ${grey('Define reporters to use')}
   ${green('-h, --help')}                  ${grey('Display this message')}
 
 Examples:
@@ -59,11 +60,12 @@ Examples:
  * * --files=Specify files to match and run
  * * --force-exit=Enable/disable force exit
  * * --timeout=Define timeout for all the tests
+ * * --reporters=Define reporters to use
  * * -h, --help=Show help
  */
-export function processCliArgs(argv: string[]): Partial<Config> {
+export function processCliArgs(argv: string[]): ProcessedCliArgs {
   const parsed = getopts(argv, {
-    string: ['tests', 'tags', 'groups', 'ignoreTags', 'files', 'timeout'],
+    string: ['tests', 'tags', 'groups', 'ignoreTags', 'files', 'timeout', 'reporters'],
     boolean: ['forceExit', 'help'],
     alias: {
       ignoreTags: 'ignore-tags',
@@ -76,6 +78,7 @@ export function processCliArgs(argv: string[]): Partial<Config> {
     filters: Filters
     timeout?: number
     forceExit?: boolean
+    defaultsReporters?: string[]
   } = { filters: {} }
 
   processAsString(parsed, 'tags', (tags) => (config.filters.tags = tags))
@@ -86,6 +89,7 @@ export function processCliArgs(argv: string[]): Partial<Config> {
   processAsString(parsed, 'groups', (groups) => (config.filters.groups = groups))
   processAsString(parsed, 'tests', (tests) => (config.filters.tests = tests))
   processAsString(parsed, 'files', (files) => (config.filters.files = files))
+  processAsString(parsed, 'reporters', (reporters) => (config.defaultsReporters = reporters))
 
   /**
    * Show help

--- a/src/ConfigResolver/index.ts
+++ b/src/ConfigResolver/index.ts
@@ -32,13 +32,13 @@ function buildReporterConfig(reporters: ReporterContract[]): NamedReporterContra
  * Build the normalized `reporters` configuration
  */
 function buildReportersConfig(
-  options: Config & { defaultsReporters?: string[] }
+  options: Config & { cliReporters?: string[] }
 ): NormalizedConfig['reporters'] {
   /**
    * Handle the new runner.reporters API
    */
   if (options.reporters && 'list' in options.reporters) {
-    let defaultsReporters = options.defaultsReporters || options.reporters.defaults || []
+    let defaultsReporters = options.cliReporters || options.reporters.defaults || []
 
     return {
       defaults: arrayify(defaultsReporters),
@@ -64,9 +64,9 @@ function buildReportersConfig(
  * Build the config object from the user defined config
  */
 export function resolveConfig<R extends ReporterContract[]>(
-  options: Config<R> & { defaultsReporters?: string[] }
+  options: Config<R> & { cliReporters?: string[] }
 ): NormalizedConfig {
-  const defaultOptions: Required<Config> & { defaultsReporters?: string[] } = {
+  const defaultOptions: Required<Config> & { cliReporters?: string[] } = {
     cwd: process.cwd(),
     files: [],
     suites: [],

--- a/src/ConfigResolver/index.ts
+++ b/src/ConfigResolver/index.ts
@@ -1,0 +1,91 @@
+import inclusion from 'inclusion'
+import { pathToFileURL } from 'url'
+import { ReporterContract, Refiner, NamedReporterContract } from '@japa/core'
+import { Config, NormalizedConfig } from '../Contracts'
+
+/**
+ * Wrap the value inside an array if it's not one
+ */
+function arrayify<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
+}
+
+/**
+ * Convert a ReporterContract object to a NamedReporterContract object
+ */
+function buildReporterConfig(reporters: ReporterContract[]): NamedReporterContract[] {
+  return reporters.map((reporter) => {
+    /**
+     * If the reporter wasn't named, then we generate a random name
+     */
+    const reporterName = reporter.name || Math.random().toString(36).substring(5)
+
+    if (typeof reporter === 'function') {
+      return { handler: reporter, name: reporterName }
+    }
+
+    return reporter
+  })
+}
+
+/**
+ * Build the normalized `reporters` configuration
+ */
+function buildReportersConfig(
+  options: Config & { defaultsReporters?: string[] }
+): NormalizedConfig['reporters'] {
+  /**
+   * Handle the new runner.reporters API
+   */
+  if (options.reporters && 'list' in options.reporters) {
+    let defaultsReporters = options.defaultsReporters || options.reporters.defaults || []
+
+    return {
+      defaults: arrayify(defaultsReporters),
+      list: buildReporterConfig(options.reporters.list),
+    }
+  }
+
+  /**
+   * Now, handle the old runner.reporters API
+   *
+   * We enable all reporters by default
+   */
+  const listReporters = buildReporterConfig(options.reporters || [])
+  const defaultsReporters = listReporters.map((reporter) => reporter.name)
+
+  return {
+    defaults: defaultsReporters,
+    list: listReporters,
+  }
+}
+
+/**
+ * Build the config object from the user defined config
+ */
+export function resolveConfig<R extends ReporterContract[]>(
+  options: Config<R> & { defaultsReporters?: string[] }
+): NormalizedConfig {
+  const defaultOptions: Required<Config> & { defaultsReporters?: string[] } = {
+    cwd: process.cwd(),
+    files: [],
+    suites: [],
+    plugins: [],
+    reporters: [],
+    timeout: 2000,
+    filters: {},
+    setup: [],
+    teardown: [],
+    importer: (filePath) => inclusion(pathToFileURL(filePath).href),
+    refiner: new Refiner({}),
+    forceExit: false,
+    configureSuite: () => {},
+  }
+
+  const mergedOptions = Object.assign(defaultOptions, options)
+
+  return {
+    ...mergedOptions,
+    reporters: buildReportersConfig(mergedOptions),
+  }
+}

--- a/src/ConfigResolver/index.ts
+++ b/src/ConfigResolver/index.ts
@@ -6,7 +6,7 @@ import { Config, NormalizedConfig } from '../Contracts'
 /**
  * Wrap the value inside an array if it's not one
  */
-function arrayify<T>(value: T | T[]): T[] {
+function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
@@ -41,7 +41,7 @@ function buildReportersConfig(
     let defaultsReporters = options.cliReporters || options.reporters.defaults || []
 
     return {
-      defaults: arrayify(defaultsReporters),
+      defaults: toArray(defaultsReporters),
       list: buildReporterConfig(options.reporters.list),
     }
   }

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -129,5 +129,5 @@ export type NormalizedConfig = Required<Config> & {
  * Type for the output of the "processCliArgs" function
  */
 export type ProcessedCliArgs = Partial<Config> & {
-  defaultsReporters?: string[]
+  cliReporters?: string[]
 }

--- a/test/config-resolver.spec.ts
+++ b/test/config-resolver.spec.ts
@@ -1,0 +1,71 @@
+import test from 'japa'
+import { resolveConfig } from '../src/ConfigResolver'
+
+test.group('resolveConfig', () => {
+  test('normalize reporters config - old api', (assert) => {
+    const firstReporter = () => {}
+    const config = resolveConfig({
+      reporters: [firstReporter],
+      files: ['foo.spec.ts'],
+    })
+
+    assert.deepEqual(config.reporters.list.length, 1)
+    assert.deepEqual(config.reporters.defaults.length, 1)
+    assert.deepEqual(config.reporters.list[0].handler, firstReporter)
+  })
+
+  test('normalize reporters config - defaults reporters from CLI args', (assert) => {
+    const firstReporter = () => {}
+    const config = resolveConfig({
+      reporters: {
+        defaults: ['spec'],
+        list: [{ name: 'spec' as const, handler: firstReporter }],
+      },
+      files: ['foo.spec.ts'],
+      defaultsReporters: ['my-reporter'],
+    })
+
+    assert.deepEqual(config.reporters, {
+      defaults: ['my-reporter'],
+      list: [{ name: 'spec', handler: firstReporter }],
+    })
+  })
+
+  test('normalize reporters config - basic', (assert) => {
+    const firstReporter = () => {}
+    const config = resolveConfig({
+      reporters: {
+        defaults: ['first'],
+        list: [{ name: 'first', handler: firstReporter }],
+      },
+      files: ['foo.spec.ts'],
+    })
+
+    assert.deepEqual(config.reporters, {
+      defaults: ['first'],
+      list: [{ name: 'first', handler: firstReporter }],
+    })
+  })
+
+  test('should enable all reporters if using old api', (assert) => {
+    const firstReporter = () => {}
+    const config = resolveConfig({
+      reporters: [firstReporter],
+      files: ['foo.spec.ts'],
+    })
+
+    assert.deepEqual(config.reporters.defaults.length, 1)
+  })
+
+  test('should typerror when defaults is not in list', (_assert) => {
+    const firstReporter = () => {}
+    resolveConfig({
+      // @ts-expect-error - Invalid config !
+      reporters: {
+        defaults: ['first'],
+        list: [{ name: 'second' as const, handler: firstReporter }],
+      },
+      files: ['foo.spec.ts'],
+    })
+  })
+})

--- a/test/config-resolver.spec.ts
+++ b/test/config-resolver.spec.ts
@@ -22,7 +22,7 @@ test.group('resolveConfig', () => {
         list: [{ name: 'spec' as const, handler: firstReporter }],
       },
       files: ['foo.spec.ts'],
-      defaultsReporters: ['my-reporter'],
+      cliReporters: ['my-reporter'],
     })
 
     assert.deepEqual(config.reporters, {

--- a/test/process-cli-argv.spec.ts
+++ b/test/process-cli-argv.spec.ts
@@ -66,7 +66,7 @@ test.group('processCliArgs', () => {
   test('collect reporters from the CLI args', (assert) => {
     assert.deepEqual(processCliArgs(['--reporters=foo,bar']), {
       filters: {},
-      defaultsReporters: ['foo', 'bar'],
+      cliReporters: ['foo', 'bar'],
     })
   })
 })

--- a/test/process-cli-argv.spec.ts
+++ b/test/process-cli-argv.spec.ts
@@ -62,4 +62,11 @@ test.group('processCliArgs', () => {
       },
     })
   })
+
+  test('collect reporters from the CLI args', (assert) => {
+    assert.deepEqual(processCliArgs(['--reporters=foo,bar']), {
+      filters: {},
+      defaultsReporters: ['foo', 'bar'],
+    })
+  })
 })


### PR DESCRIPTION
Linked to #23 

## Refactor
- Moved what is related to CLI parsing into its own file
- Moved what is related to configuration and configuration normalization to its own file

## What has been added 

- a `--reporters` arguments
- New API for `configure.reporters` property, but backward compatible. the `configure.reporters.defaults` property is typesafe and and based on what `configure.reporters.list` contains. 

To keep the API retro-compatible, but also to keep the code simple, I made some functions to "normalize" the configuration. So even if the old API is used, then this function will convert that into the same format as the new one. ( with the `defaults` and `list` properties. )

If the old API is used, then all reporters are activated by default

The `--reporters` flag overrides the `reporters.defaults` property

To merge this PR it will be necessary in priority to merge this one: 
https://github.com/japa/core/pull/65
Then update @japa/core

Let me know if anything seems unclear or if anything needs to be changed