### PR TITLE
feat: add getActiveTestOrFail method

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,12 +89,7 @@ export function test(title: string, callback?: TestExecutor<TestContext, undefin
 test.group = function (title: string, callback: (group: Group) => void): Group {
   validator.ensureIsInPlanningPhase(executionPlanState.phase)
 
-  const group = createTestGroup(
-    title,
-    emitter,
-    runnerConfig!.refiner,
-    executionPlanState
-  )
+  const group = createTestGroup(title, emitter, runnerConfig!.refiner, executionPlanState)
   executionPlanState.group = group
 
   /**

--- a/index.ts
+++ b/index.ts
@@ -134,6 +134,14 @@ export function getActiveTest() {
 }
 
 /**
+ * Get the test of currently running test or throw an error
+ */
+export function getActiveTestOrFail() {
+  if (!activeTest) throw new Error('Cannot access active test outside of a test callback')
+  return activeTest
+}
+
+/**
  * Make Japa process command line arguments. Later the parsed output
  * will be used by Japa to compute the configuration
  */


### PR DESCRIPTION
i've been copy-pasting this small helper in all my codebases for years now ahah. 

basically, `getActiveTest()` returns a `Test | undefined`

so to help typescript a bit i always set up this handy helper.
